### PR TITLE
El employeedepts

### DIFF
--- a/controllers/employeeCtrl.js
+++ b/controllers/employeeCtrl.js
@@ -1,10 +1,14 @@
 'use strict'
 
 module.exports.getEmployees = (req, res, next) => {
+  // console.log("models?", models);
   const { Employee } = req.app.get('models');
-  Employee.findAll() // love those built-in Sequelize methods
+  const { Department } = req.app.get('models');
+  Employee.findAll({include: [Department]}) 
     .then( (employees) => {
+      console.log("employees", employees);
       let emps = employees.map( (emps) => {
+        // emps.deptName = ;
         return emps.dataValues;
       });
       res.render('employees', {emps});

--- a/controllers/employeeCtrl.js
+++ b/controllers/employeeCtrl.js
@@ -1,17 +1,14 @@
 'use strict'
 
 module.exports.getEmployees = (req, res, next) => {
-  // console.log("models?", models);
   const { Employee } = req.app.get('models');
-  const { Department } = req.app.get('models');
-  Employee.findAll({include: [Department]}) 
+  const { Department } = req.app.get('models'); //require this in order to include it below
+  Employee.findAll({include: [Department]}) //include Department and it becomes a property on the incoming GET
     .then( (employees) => {
-      console.log("employees", employees);
       let emps = employees.map( (emps) => {
-        // emps.deptName = ;
         return emps.dataValues;
       });
-      res.render('employees', {emps});
+      res.render('employees', {emps});  //in PUG you just take it one dot further (emps.Department.whateverPropertyYouWanted)
   })
   .catch( (err) => {
     next(err); //Ship this nastyness off to our error handler at the bottom of the middleware stack in app.js

--- a/views/employees.pug
+++ b/views/employees.pug
@@ -3,4 +3,4 @@ extends index.pug
 block content
     ul
         each employee in emps
-            li Name: #{employee.first_name} #{employee.last_name}<br>Department #{employee.dept_id}<br> Employee Id: #{employee.id}
+            li Name: #{employee.first_name} #{employee.last_name}<br>Department: #{employee.Department.name}<br>Employee Id: #{employee.id}


### PR DESCRIPTION
What changed:

The function to get the employees now includes a join on the Department table. 

This is so that we can display the name (or other properties if we wanted) of the Department associated with an employee.

TO TEST:
Run `npm start`
Go to `http://localhost:4000/employees`
Note that the Department displays as a word and not a number.